### PR TITLE
Add DynamoDBMapper initialization

### DIFF
--- a/doc_source/getting-started-store-query-app-data.rst
+++ b/doc_source/getting-started-store-query-app-data.rst
@@ -111,6 +111,14 @@ constructor::
     AmazonDynamoDBClient ddbClient = new AmazonDynamoDBClient(credentialsProvider);
 
 
+Initialize DynamoDBMapper
+=========================
+
+Pass your initialized DynamoDB client to the :code:`DynamoDBMapper` constructor::
+
+    DynamoDBMapper mapper = new DynamoDBMapper(ddbClient);
+
+
 Write a Row
 ===========
 


### PR DESCRIPTION
The use of `mapper` is shown. 
This adds a step explaining how to create it.
